### PR TITLE
Changement de la couleur des liens

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -26,5 +26,6 @@ a {
 }
 
 a:hover {
-    background-color: #5c1c30;
+    color: #5c1c54;
+    text-decoration: underline;
 }


### PR DESCRIPTION
Le fond lors du survol des liens est illisible.
![image](https://user-images.githubusercontent.com/841858/114716276-3354fc80-9d34-11eb-9754-13c40952d675.png)

Je propose de simplement garder le fait de souligner le texte au survol
![image](https://user-images.githubusercontent.com/841858/114716383-4bc51700-9d34-11eb-8d88-61c0b798d2bd.png)
